### PR TITLE
Disables react/jsx-curly-brace-presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Disabled, allowing you to have multiple expressions, including plain text and wh
 
 This rule enforces a consistent indentation style in JSX. 4 spaces.
 
+### ```'react/jsx-curly-brace-presence': 0```
+
+This rule controls the use of curly braces. It fails to allow `'{ }'` except when configuring the rule to ignore children completely, so we disables the rule.
+
+It's an [issue with eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/issues/1717), so the rule should be enabled again when updating to the next stable version of eslint-plugin-react.
+
 ### ```'import/no-unresolved': 0```
 
 Ensures an imported module can be resolved to a module on the local filesystem.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-config-colourbox",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "This package provides Colourbox's .eslintrc as an extensible shared config.",
     "main": "index.js",
     "scripts": {

--- a/rules/colourbox.js
+++ b/rules/colourbox.js
@@ -30,6 +30,7 @@ module.exports = {
         'jsx-a11y/no-noninteractive-element-interactions': 0,
         'jsx-a11y/media-has-caption': 0,
         'react/no-danger': 0,
+        'react/jsx-curly-brace-presence': 0,
         'no-restricted-syntax': [
             'error',
             'ForStatement',


### PR DESCRIPTION
I had to disable this rule, because it cannot be configured to accept whitespace like this in JSX: `{' '}`. It's an issue with eslint-plugin-react.